### PR TITLE
Filtered inactive stations when calling data Issue #8 (partial)

### DIFF
--- a/task_geo/data_sources/noaa/__init__.py
+++ b/task_geo/data_sources/noaa/__init__.py
@@ -26,6 +26,8 @@ def noaa_api(countries, start_date, end_date=None, metrics=None, country_aggr=Fa
             SNOW: Snowfall (mm).
             SNWD: Snow depth (mm).
             PRCP: Precipitation.
+            PSUN: Daily percent of possible sunshine (percent)
+            TSUN: Daily total sunshine (minutes)
         country_aggr(bool): When True, only an aggregate for each date/country will be returned.
 
     Example:
@@ -36,4 +38,5 @@ def noaa_api(countries, start_date, end_date=None, metrics=None, country_aggr=Fa
     >>> noaa_api(countries, start_date, end_date)
     """
     raw = noaa_api_connector(countries, start_date, end_date, metrics)
+
     return noaa_api_formatter(raw, metrics, country_aggr)

--- a/task_geo/data_sources/noaa/noaa_api_connector.py
+++ b/task_geo/data_sources/noaa/noaa_api_connector.py
@@ -30,7 +30,7 @@ logging.basicConfig(level=logging.DEBUG)
 logging.getLogger("urllib3").setLevel(logging.WARNING)
 
 
-DEFAULT_METRICS = ['TMAX', 'TMIN', 'TAVG', 'PCRP', 'SNOW', 'SNWD']
+DEFAULT_METRICS = ['TMAX', 'TMIN', 'TAVG', 'PCRP', 'SNOW', 'SNWD', 'PSUN', 'TSUN']
 
 
 def get_stations_by_country(country):
@@ -70,6 +70,8 @@ def get_request_urls(country, start_date, end_date=None, metrics=None):
             SNOW: Snowfall (mm).
             SNWD: Snow depth (mm).
             PRCP: Precipitation.
+            PSUN: Daily percent of possible sunshine (percent)
+            TSUN: Daily total sunshine (minutes)
 
     Returns:
         str
@@ -94,6 +96,10 @@ def get_request_urls(country, start_date, end_date=None, metrics=None):
     end = end_date.date().isoformat()
 
     stations_list = get_stations_by_country(country)
+    inventory_data = load_dataset('inventory')
+    inventory_data = inventory_data[inventory_data.start_date >= start_date.year]
+    inventory_data = inventory_data[inventory_data.end_date <= end_date.year]
+    stations_list = [x for x in stations_list if x in inventory_data.ID]
     if len(stations_list) < max_stations_req:
         stations = ','.join(stations_list)
         return [
@@ -160,6 +166,9 @@ def noaa_api_connector(countries, start_date, end_date=None, metrics=None):
             TAVG: Average of temperature.
             SNOW: Snowfall (mm).
             SNWD: Snow depth (mm).
+            PRCP: Precipitation.
+            PSUN: Daily percent of possible sunshine (percent)
+            TSUN: Daily total sunshine (minutes)
 
     Returns:
         tuple[list[dict], list[Exception]]
@@ -196,4 +205,5 @@ def noaa_api_connector(countries, start_date, end_date=None, metrics=None):
         metrics = DEFAULT_METRICS
 
     columns.extend([metric for metric in metrics if metric in data.columns])
+
     return data[columns]


### PR DESCRIPTION
1. Filtering inactive stations based on start date supplied 
2. Added PSUN, TSUN in metrics (SNOW already present)

#########

**IMPORTANT NOTICE**

Before opening the Pull Request make sure that you:

- Have read the **[CONTRIBUTING GUIDE](https://coronawhy.github.io/task-geo/contributing.html)**
- Have read the **[DATA MODEL](https://coronawhy.github.io/task-geo/data_model.html)** and **[DATA SOURCES](https://coronawhy.github.io/task-geo/data_sources.html)** documentation.
- Have check that your code is compliant with both.
- Delete this notice, failing to do so will result in this PR being closed without prior review.

#########

# Description

Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes #8 (issue)(partially)


# Checklist:

- [x] I have read the [CONTRIBUTING GUIDE](https://coronawhy.github.io/task-geo/contributing.html) and made sure this Pull Request is compliant with it.
- [x] I have read the [DATA MODEL](https://coronawhy.github.io/task-geo/data_model.html) and [DATA SOURCES](https://coronawhy.github.io/task-geo/data_sources.html) and made sure this Pull Request is compliant with it.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules