### PR TITLE
gh 75 fix missing sub_region field in mobility data

### DIFF
--- a/task_geo/data_sources/mobility/audit.md
+++ b/task_geo/data_sources/mobility/audit.md
@@ -15,7 +15,11 @@
 
 
 **region**
-- Description: Name of the region
+- Description: Name of the region (e.g. a state within a country)
+- Type: string
+
+**sub_region**
+- Description: Name of the sub_region (e.g. a county within a state)
 - Type: string
 
 **date**

--- a/task_geo/data_sources/mobility/datapackage.json
+++ b/task_geo/data_sources/mobility/datapackage.json
@@ -12,7 +12,12 @@
                 },
                 {
                     "name": "region",
-                    "description": "Name of the region",
+                    "description": "Name of the region (e.g. a state within a country)",
+                    "type": "string"
+                },
+                {
+                    "name": "sub_region",
+                    "description": "Name of the sub_region (e.g. a county within a state)",
                     "type": "string"
                 },
                 {

--- a/task_geo/data_sources/mobility/mobility_formatter.py
+++ b/task_geo/data_sources/mobility/mobility_formatter.py
@@ -26,7 +26,7 @@ def mobility_formatter(raw):
     raw[numeric_columns] = raw[numeric_columns].astype(float)
     raw['date'] = pd.to_datetime(raw.date)
     column_order = [
-        'country_iso', 'country', 'region', 'sub_region', 'date', 'retail_recreation', 'grocery_pharmacy',
-        'parks', 'transit_stations', 'workplaces', 'residential'
+        'country_iso', 'country', 'region', 'sub_region', 'date', 'retail_recreation',
+        'grocery_pharmacy', 'parks', 'transit_stations', 'workplaces', 'residential'
     ]
     return raw[column_order]

--- a/task_geo/data_sources/mobility/mobility_formatter.py
+++ b/task_geo/data_sources/mobility/mobility_formatter.py
@@ -26,7 +26,7 @@ def mobility_formatter(raw):
     raw[numeric_columns] = raw[numeric_columns].astype(float)
     raw['date'] = pd.to_datetime(raw.date)
     column_order = [
-        'country_iso', 'country', 'region', 'date', 'retail_recreation', 'grocery_pharmacy',
+        'country_iso', 'country', 'region', 'sub_region', 'date', 'retail_recreation', 'grocery_pharmacy',
         'parks', 'transit_stations', 'workplaces', 'residential'
     ]
     return raw[column_order]


### PR DESCRIPTION
# Description

Resolves #75
fixes the missing sub_region field in mobility data which is needed

# Checklist:

- [x] I have read the [CONTRIBUTING GUIDE](https://coronawhy.github.io/task-geo/contributing.html) and made sure this Pull Request is compliant with it.
- [x] I have read the [DATA MODEL](https://coronawhy.github.io/task-geo/data_model.html) and [DATA SOURCES](https://coronawhy.github.io/task-geo/data_sources.html) and made sure this Pull Request is compliant with it.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules